### PR TITLE
Add rust-packaging skill capturing sracat-rs packaging/release conventions

### DIFF
--- a/.claude/skills/rust-packaging/SKILL.md
+++ b/.claude/skills/rust-packaging/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: rust-packaging
+description: >-
+  Package and release a Rust project the "sracat-rs / bird_tool_utils" way —
+  the conventions Ben Woodcroft (wwood) uses across his Rust crates. Use when
+  setting up a freshly `cargo new`ed crate, migrating an existing crate to
+  these conventions, or wiring up releases. Covers Cargo.toml metadata and
+  profiles, a keep-a-changelog CHANGELOG, the release.py / cargo-release flow,
+  cargo-dist prebuilt binaries + shell installer, crates.io + bioconda,
+  optional pixi for native/conda deps, a cargo fmt pre-commit hook, and CI +
+  release GitHub Actions workflows.
+---
+
+# Rust packaging & release (the sracat-rs way)
+
+This skill reproduces how `wwood/sracat-rs` (a binary crate) and
+`wwood/bird_tool_utils` (a library crate) are packaged and released, and
+extends them with a `cargo fmt` hook and CI. Bundled templates live in
+`templates/` next to this file — copy them into the target project and fill in
+the placeholders rather than writing these files from scratch.
+
+## First decision: library or binary?
+
+The whole flow forks on this. Determine it before doing anything else (look for
+`src/main.rs` + `[[bin]]` vs a pure `src/lib.rs`).
+
+| Aspect          | Library crate (e.g. bird_tool_utils) | Binary crate (e.g. sracat-rs) |
+| --------------- | ------------------------------------ | ----------------------------- |
+| `Cargo.lock`    | **gitignored**                       | **committed**                 |
+| cargo-dist      | not used                             | used (prebuilt binaries)      |
+| Release command | `release.py --version X --library-only` | `release.py --version X`   |
+| Publish target  | crates.io                            | crates.io + GitHub Release + bioconda |
+| GitHub Actions  | CI only                              | CI + `release.yml` (dist)     |
+
+When in doubt or when a crate is both, treat it as a binary crate but still
+`cargo publish` the library.
+
+## Setting up a NEW project (`cargo new`)
+
+1. `cargo new CRATE` (add `--lib` for a library). Prefer `edition = "2021"`.
+2. **Cargo.toml metadata + profiles.** Merge `templates/Cargo.snippet.toml`
+   into the generated `Cargo.toml`: fill `description`, `license`, `repository`
+   (+ `homepage`/`documentation`/`readme` for libraries), add `[profile.release]`
+   with `lto = true` and `codegen-units = 1`. Add an explicit `[[bin]]` for
+   binaries.
+3. **LICENSE.** Add a `LICENSE`/`LICENSE.txt` matching the `license` field
+   (sracat-rs uses MIT; bird_tool_utils uses GPL-3.0 — follow the project's
+   choice).
+4. **CHANGELOG.** Copy `templates/CHANGELOG.md`. See the CHANGELOG section below.
+5. **.gitignore.** Ensure `/target` is ignored. Library crates also ignore
+   `Cargo.lock`; binary crates commit it. If using pixi, ignore `.pixi/*`
+   (keep `!.pixi/config.toml`).
+6. **cargo fmt hook** — see the dedicated section below (always do this).
+7. **CI workflow** — copy `templates/workflows/ci.yml` to
+   `.github/workflows/ci.yml`.
+8. **Release tooling:**
+   - Copy `templates/release.py` to `scripts/release.py` (chmod +x).
+   - Optionally copy `templates/release.toml` if you prefer `cargo release`.
+   - Binary crates: initialise cargo-dist — see the cargo-dist section.
+9. `git init` if needed, commit, push, and confirm CI is green.
+
+## MIGRATING an existing project
+
+Do the same as a new project, but additively and carefully:
+
+1. Classify it (library vs binary) and fix `Cargo.lock` tracking accordingly
+   (add to / remove from git + `.gitignore`).
+2. Backfill `Cargo.toml` metadata and the `[profile.release]` / `[profile.dist]`
+   / `[workspace.metadata.dist]` blocks that are missing (don't clobber existing
+   dependency or feature config).
+3. If there's no CHANGELOG, create one and reconstruct recent history from
+   `git tag` / release notes into `## Version X.Y.Z` sections, newest first,
+   with a `## Unreleased` at the top.
+4. Add the cargo fmt hook + `ci.yml`. Run `cargo fmt --all` once as its own
+   commit ("cargo fmt") so the formatting churn doesn't pollute later diffs,
+   then fix any `cargo clippy -- -D warnings` findings.
+5. Add `scripts/release.py`; for binaries run `dist init`.
+6. Verify: `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`,
+   `cargo test`, and for binaries `dist plan`.
+
+## CHANGELOG conventions
+
+Keep-a-changelog style, newest first. A `## Unreleased` section sits at the top;
+under it and each release use `### Added` / `### Fixed` / `### Changed`
+subsections. Release headings are `## Version X.Y.Z`. During a release the
+tooling moves the `Unreleased` bullets into a new `## Version X.Y.Z` section —
+so **write user-facing notes under `## Unreleased` as you go**, and both
+`release.py` and `release.toml` will roll them forward for you.
+
+## cargo fmt hook (do this on every project)
+
+Two layers — a local hook for fast feedback, and a CI job that cannot be
+bypassed.
+
+1. **Local pre-commit hook.** Either:
+   - **Plain git hook (no dependencies):** copy `templates/pre-commit` to
+     `scripts/pre-commit`, then install it in each clone:
+     `ln -sf ../../scripts/pre-commit .git/hooks/pre-commit`. It runs
+     `cargo fmt --all -- --check` and blocks the commit on unformatted code.
+     Because git hooks aren't committed, document that install line in the
+     README/CONTRIBUTING.
+   - **pre-commit framework:** copy `templates/.pre-commit-config.yaml` to the
+     repo root and run `pre-commit install`. Prefer this only if the project
+     already uses pre-commit; it also wires up clippy.
+2. **CI enforcement.** `templates/workflows/ci.yml` includes a dedicated
+   `rustfmt` job (`cargo fmt --all -- --check`) — this is the real guard, since
+   a local hook can be skipped with `--no-verify`.
+3. Rely on default rustfmt style. Only add a `rustfmt.toml` if the project
+   genuinely needs overrides; keep it minimal and commit it.
+
+## GitHub Actions
+
+1. **CI (`ci.yml`) — every crate.** Copy `templates/workflows/ci.yml` to
+   `.github/workflows/ci.yml`. It runs on push to `main` and all PRs:
+   - `rustfmt` job: `cargo fmt --all -- --check`
+   - `clippy + test` job: `cargo clippy --all-targets --all-features -- -D warnings`
+     then `cargo test --all`, with `Swatinem/rust-cache` for speed.
+   For crates with native/conda deps, swap the toolchain setup for the pixi
+   block documented at the bottom of that template.
+2. **Release (`release.yml`) — binary crates only.** This is **autogenerated by
+   cargo-dist** — do not hand-write or hand-edit it. Run `dist init` (see next
+   section); it writes `.github/workflows/release.yml`. It triggers on tags
+   matching `**[0-9]+.[0-9]+.[0-9]+*` (and on PRs, for validation), builds the
+   configured targets, and creates a GitHub Release with the artifacts + shell
+   installer. Re-run `dist generate` after changing dist config so the workflow
+   stays in sync.
+3. **build-setup (native deps).** If the crate links native/conda libraries,
+   `cargo build` in the release runner won't find them. Point
+   `github-build-setup` in Cargo.toml at
+   `templates/workflows/build-setup.yml` (place it under
+   `.github/workflows/build-setup/`) to provision them with pixi before each
+   build. See how sracat-rs static-links ncbi-vdb.
+
+## cargo-dist (binary crates)
+
+Prebuilt binaries + a `curl | sh` installer are produced by
+[cargo-dist](https://opensource.axo.dev/cargo-dist/):
+
+1. Install the pinned `dist` (match `cargo-dist-version` in Cargo.toml, e.g.
+   0.31.0).
+2. `dist init` — writes `[workspace.metadata.dist]` and
+   `.github/workflows/release.yml`. Then edit the metadata toward the template
+   values: `installers = ["shell"]`, `install-updater = false`,
+   `install-path = "CARGO_HOME"`, and a **deliberate** `targets` list (default
+   is broad; sracat-rs restricts to `x86_64-unknown-linux-gnu` because its
+   conda ncbi-vdb dependency only exists for glibc x86_64 — only widen targets
+   once a matching build env/runner exists).
+3. `dist plan` locally to sanity-check before tagging.
+
+## Release process
+
+Both crates use `scripts/release.py` (bundled as `templates/release.py`). It:
+validates the version, refuses a dirty tree / existing tag, confirms + rolls the
+CHANGELOG `Unreleased` section into `## Version X.Y.Z`, bumps the Cargo.toml
+version, `cargo update`, `cargo test`, (binaries) `dist plan`, commits, tags
+`vX.Y.Z`, `cargo publish`, and pushes with tags.
+
+- **Library:** `python scripts/release.py --version X.Y.Z --library-only`
+  (skips cargo-dist; publishes the crate to crates.io).
+- **Binary:** `python scripts/release.py --version X.Y.Z` — the pushed tag
+  triggers `release.yml`, which builds and attaches the binaries + installer to
+  the GitHub Release. Then update the bioconda recipe and open a PR against
+  `bioconda-recipes`.
+- `cargo release X.Y.Z` (via `release.toml`) is an equivalent alternative if you
+  prefer it to the Python script; don't run both.
+
+Prerelease versions (`X.Y.Z-beta.1`) are supported by the version validator and
+are marked as prereleases by cargo-dist automatically.
+
+## pixi (optional — native / conda dependencies)
+
+Only for crates that depend on non-Rust libraries (like sracat-rs → ncbi-vdb).
+A `pixi.toml` declares conda channels (`conda-forge`, `bioconda`), the native
+deps, the Rust toolchain, and `[tasks]` (`build`, `test`, ...). `build.rs` reads
+`CONDA_PREFIX` from the pixi env to find headers/libs. If you use pixi, add a
+`.gitattributes` line so the lockfile doesn't cause merge noise:
+`pixi.lock merge=binary linguist-language=YAML linguist-generated=true -diff`,
+and gitignore `.pixi/*` (keeping `!.pixi/config.toml`). Pure-Rust crates ignore
+this whole section.
+
+## Verification checklist
+
+Before considering a project done:
+- [ ] `cargo fmt --all -- --check` clean; pre-commit hook installed/documented.
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean.
+- [ ] `cargo test` (or `pixi run test`) passes.
+- [ ] `Cargo.toml` has description, license, repository, and release profile.
+- [ ] `Cargo.lock` tracked (binary) or gitignored (library).
+- [ ] CHANGELOG has an `## Unreleased` section.
+- [ ] `.github/workflows/ci.yml` present and green.
+- [ ] Binary crates: `dist plan` succeeds and `release.yml` exists.

--- a/.claude/skills/rust-packaging/templates/.pre-commit-config.yaml
+++ b/.claude/skills/rust-packaging/templates/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# Alternative to the plain scripts/pre-commit hook, using the pre-commit
+# framework (https://pre-commit.com). Install once with `pre-commit install`;
+# it then runs cargo fmt (and clippy) before every commit. Prefer this if the
+# project already uses pre-commit for other languages; otherwise the plain
+# scripts/pre-commit hook has zero extra dependencies.
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all --
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --all-targets --all-features -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false

--- a/.claude/skills/rust-packaging/templates/CHANGELOG.md
+++ b/.claude/skills/rust-packaging/templates/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## Unreleased
+
+## Version 0.1.0
+
+### Added
+- Initial release.

--- a/.claude/skills/rust-packaging/templates/Cargo.snippet.toml
+++ b/.claude/skills/rust-packaging/templates/Cargo.snippet.toml
@@ -1,0 +1,36 @@
+# Snippets to merge into a project's Cargo.toml.
+# Keep [package] as cargo new generated it, then add the metadata below.
+
+[package]
+# name / version / edition come from `cargo new`. Fill these in:
+description = "One-line description of the crate"
+license = "MIT"                 # or "GPL-3.0", matching the LICENSE file
+repository = "https://github.com/wwood/CRATE"
+# homepage / documentation / readme are worth setting for library crates too.
+
+# --- Binary crates: declare the bin explicitly ---------------------------
+# [[bin]]
+# name = "CRATE"
+# path = "src/main.rs"
+
+# --- Release profile: optimise the shipped binary ------------------------
+[profile.release]
+lto = true
+codegen-units = 1
+
+# --- cargo-dist: prebuilt binaries + installers (BINARY crates only) -----
+# Generated/managed by `dist init`; shown here so you know what to expect.
+# Libraries skip everything below and release with `cargo publish` only.
+[profile.dist]
+inherits = "release"
+lto = "thin"
+
+[workspace.metadata.dist]
+cargo-dist-version = "0.31.0"        # pin; matches the installed `dist`
+ci = "github"
+installers = ["shell"]
+targets = ["x86_64-unknown-linux-gnu"]  # add platforms as runners/deps allow
+install-updater = false
+install-path = "CARGO_HOME"
+# Only for crates with native deps that need pre-build provisioning:
+# github-build-setup = "build-setup/build-setup.yml"

--- a/.claude/skills/rust-packaging/templates/pre-commit
+++ b/.claude/skills/rust-packaging/templates/pre-commit
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# cargo fmt pre-commit hook.
+#
+# Install (from repo root):
+#   ln -sf ../../scripts/pre-commit .git/hooks/pre-commit
+# (copy this file to scripts/pre-commit first, or point the symlink at wherever
+# you keep it). git hooks are per-clone and are NOT committed, so document the
+# install line in the README/CONTRIBUTING and back it up with the CI fmt job.
+#
+# Fails the commit if any tracked Rust code is not rustfmt-clean. Run
+# `cargo fmt --all` to fix, then re-stage.
+set -euo pipefail
+
+if ! cargo fmt --all -- --check; then
+    echo >&2
+    echo "error: rustfmt found unformatted code." >&2
+    echo "       run 'cargo fmt --all', then 'git add' and commit again." >&2
+    exit 1
+fi

--- a/.claude/skills/rust-packaging/templates/release.py
+++ b/.claude/skills/rust-packaging/templates/release.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess:
+    print(f"+ {' '.join(cmd)}")
+    return subprocess.run(cmd, check=check)
+
+
+def capture(cmd: list[str]) -> str:
+    return subprocess.check_output(cmd, text=True).strip()
+
+
+def die(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def validate_version(version: str) -> None:
+    if not re.fullmatch(r"\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?", version):
+        die(
+            f"invalid version {version!r}; expected something like "
+            "1.2.3, 1.2.3-beta.1, or 1.2.3+build.1"
+        )
+
+
+def check_clean_git() -> None:
+    status = capture(["git", "status", "--porcelain"])
+    if status:
+        die("git working tree is not clean; commit or stash changes first")
+
+
+def update_cargo_toml(version: str, path: Path) -> None:
+    if not path.exists():
+        die(f"{path} not found")
+
+    text = path.read_text()
+
+    # This updates the first `version = "..."`
+    # In a normal single-crate Cargo.toml, that is usually [package].version.
+    new_text, count = re.subn(
+        r'(?m)^version\s*=\s*"[^"]+"',
+        f'version = "{version}"',
+        text,
+        count=1,
+    )
+
+    if count != 1:
+        die(f"could not find exactly one package version line in {path}")
+
+    path.write_text(new_text)
+    print(f"Updated {path}: version = {version!r}")
+
+
+def changelog_contains_version(version: str, path: Path) -> bool:
+    if not path.exists():
+        return False
+
+    text = path.read_text()
+    patterns = [
+        rf"(?m)^##\s+\[?v?{re.escape(version)}\]?\b",
+        rf"(?m)^##\s+Version\s+v?{re.escape(version)}\b",
+        rf"(?m)^#\s+\[?v?{re.escape(version)}\]?\b",
+    ]
+    return any(re.search(p, text) for p in patterns)
+
+
+def confirm_changelog(version: str) -> None:
+    changelog = Path("CHANGELOG.md")
+
+    if not changelog.exists():
+        die("CHANGELOG.md not found")
+
+    if changelog_contains_version(version, changelog):
+        print(f"CHANGELOG.md appears to contain a section for {version}.")
+    else:
+        print(f"CHANGELOG.md does not obviously contain a section for {version}.")
+
+    while True:
+        answer = input("Has CHANGELOG.md been updated for this release (in the Unreleased section)? [y/n] ").strip().lower()
+        if answer in {"y", "yes"}:
+            return
+        if answer in {"n", "no"}:
+            die("update CHANGELOG.md first, then rerun this script")
+
+def update_changelog(version: str, path: Path) -> bool:
+    if not path.exists():
+        die(f"{path} not found")
+
+    text = path.read_text()
+
+    # Already has this version section?
+    if changelog_contains_version(version, path):
+        print(f"{path} already contains a section for {version}; not moving Unreleased.")
+        return False
+
+    unreleased_match = re.search(
+        r"(?m)^##\s+Unreleased\s*$",
+        text,
+    )
+    if not unreleased_match:
+        die(f"could not find '## Unreleased' section in {path}")
+
+    next_heading_match = re.search(
+        r"(?m)^##\s+",
+        text[unreleased_match.end():],
+    )
+
+    if not next_heading_match:
+        die(f"could not find next '##' release section after Unreleased in {path}")
+
+    unreleased_start = unreleased_match.end()
+    next_heading_start = unreleased_match.end() + next_heading_match.start()
+
+    unreleased_body = text[unreleased_start:next_heading_start].strip()
+
+    if not unreleased_body:
+        die("CHANGELOG.md Unreleased section is empty; nothing to release")
+
+    before_unreleased_body = text[:unreleased_start]
+    after_unreleased_body = text[next_heading_start:]
+
+    new_section = f"\n\n## Version {version}\n\n{unreleased_body}\n\n"
+
+    new_text = before_unreleased_body.rstrip() + new_section + after_unreleased_body.lstrip()
+
+    path.write_text(new_text)
+    print(f"Moved CHANGELOG.md Unreleased entries to Version {version}")
+    return True
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Prepare a Rust release for cargo-dist."
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Release version, e.g. 1.2.3",
+    )
+    parser.add_argument(
+        "--no-commit",
+        action="store_true",
+        help="Modify files but do not commit or tag",
+    )
+    parser.add_argument(
+        "--no-lock-update",
+        action="store_true",
+        help="Do not run `cargo update --workspace` after editing Cargo.toml",
+    )
+    parser.add_argument(
+        "--tag-prefix",
+        default="v",
+        help='Git tag prefix; default is "v", producing tags like v1.2.3',
+    )
+    parser.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="Allow running with an already-dirty git working tree",
+    )
+    parser.add_argument(
+        "--library-only",
+        action="store_true",
+        help="Skip `dist plan` (cargo-dist) and release as a plain library crate via `cargo publish`",
+    )
+
+    args = parser.parse_args()
+    version = args.version
+    tag = f"{args.tag_prefix}{version}"
+
+    validate_version(version)
+
+    if not args.allow_dirty:
+        check_clean_git()
+
+    existing_tags = capture(["git", "tag", "--list", tag])
+    if existing_tags:
+        die(f"git tag {tag!r} already exists")
+
+    confirm_changelog(version)
+
+    update_changelog(version, Path("CHANGELOG.md"))
+
+    update_cargo_toml(version, Path("Cargo.toml"))
+
+    if not args.no_lock_update:
+        run(["cargo", "update", "--workspace"])
+
+    run(["cargo", "test"])
+    if not args.library_only:
+        run(["dist", "plan"])
+
+    if args.no_commit:
+        print()
+        print("Stopped before commit/tag because --no-commit was supplied.")
+        print("Review changes with:")
+        print("  git diff")
+        return
+
+    files_to_add = ["Cargo.toml", "CHANGELOG.md"]
+    if not args.library_only:
+        files_to_add.append("Cargo.lock")
+    run(["git", "add", *files_to_add])
+    run(["git", "commit", "-m", f"Release {tag}"])
+    run(["git", "tag", tag])
+
+    publish_cmd = ["cargo", "publish"]
+    if args.allow_dirty:
+        publish_cmd.append("--allow-dirty")
+    run(publish_cmd)
+    run(["git", "push", "origin", "HEAD", "--tags"])
+
+    print()
+    if args.library_only:
+        print("Done I think.")
+    else:
+        print("Release commit and tag created, pushed to GitHub, and published to crates.io. Next update the bioconda recipe and submit a PR to bioconda-recipes.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/rust-packaging/templates/release.toml
+++ b/.claude/skills/rust-packaging/templates/release.toml
@@ -1,0 +1,15 @@
+# cargo-release config (https://github.com/crate-ci/cargo-release).
+# Used only if you drive releases with `cargo release` instead of the bundled
+# release.py. Both do the same job: bump the version, roll CHANGELOG's
+# "## Unreleased" into a versioned section, commit, and tag v{{version}}.
+tag-name = "v{{version}}"
+tag-message = "Release v{{version}}"
+pre-release-commit-message = "Release v{{version}}"
+
+[[pre-release-replacements]]
+file = "CHANGELOG.md"
+search = "## Unreleased"
+replace = """## Unreleased
+
+## Version {{version}}"""
+exactly = 1

--- a/.claude/skills/rust-packaging/templates/workflows/build-setup.yml
+++ b/.claude/skills/rust-packaging/templates/workflows/build-setup.yml
@@ -1,0 +1,25 @@
+# Custom steps cargo-dist injects before each release build job. Only needed
+# when the crate links native/conda libraries that a bare `cargo build` in CI
+# cannot find (e.g. sracat-rs static-links ncbi-vdb from a pixi env).
+#
+# Wire it up in Cargo.toml:
+#   [workspace.metadata.dist]
+#   github-build-setup = "build-setup/build-setup.yml"
+# then place this file at .github/workflows/build-setup/build-setup.yml and
+# re-run `dist generate` (or `dist init`).
+#
+# cargo-dist runs `cargo build` directly (not inside `pixi run`), so these steps
+# provision the deps via pixi and export the env vars build.rs reads. Adapt the
+# env-var names to whatever your build.rs looks for.
+- name: Set up pixi
+  uses: prefix-dev/setup-pixi@v0.8.1
+  with:
+    manifest-path: pixi.toml
+- name: Install native deps + toolchain into the pixi env
+  run: pixi install
+- name: Point the build at the pixi env (adjust to your build.rs)
+  shell: bash
+  run: |
+    echo "CONDA_PREFIX=$PWD/.pixi/envs/default" >> "$GITHUB_ENV"
+    # e.g. force static linking so the released binary is self-contained:
+    # echo "MYCRATE_LINK=static" >> "$GITHUB_ENV"

--- a/.claude/skills/rust-packaging/templates/workflows/ci.yml
+++ b/.claude/skills/rust-packaging/templates/workflows/ci.yml
@@ -1,0 +1,51 @@
+# Continuous integration: format check, lint, and test on every push/PR.
+# Drop into .github/workflows/ci.yml. This is the CI guard that backs up the
+# local cargo-fmt pre-commit hook (a hook can be skipped; CI cannot).
+#
+# Pure-Rust crates work as-is. If the crate needs native/conda dependencies
+# (see build.rs + pixi), replace the toolchain setup with the pixi block at the
+# bottom of this file so `cargo test` can find the C headers/libs.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy-test:
+    name: clippy + test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+      - run: cargo test --all
+
+# --- Variant for crates with native/conda deps (pixi) --------------------
+# Replace the two jobs above's toolchain + build steps with:
+#
+#   - uses: actions/checkout@v4
+#   - uses: prefix-dev/setup-pixi@v0.8.1
+#     with:
+#       manifest-path: pixi.toml
+#   - run: pixi install
+#   - run: pixi run test      # a [tasks]/[feature.dev.tasks] entry in pixi.toml
+#
+# and let the pixi env supply the Rust toolchain, C compiler, and libraries.


### PR DESCRIPTION
Extracts the packaging and release workflow used across the author's Rust
crates (sracat-rs binary, bird_tool_utils library) into a reusable skill for
new (cargo new) and existing projects. Bundles templates for the release
helper, cargo-dist/CI/build-setup GitHub Actions workflows, a cargo fmt
pre-commit hook, CHANGELOG, and Cargo.toml metadata snippets.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012UgGme7jYDu2jQuLQmXVGg